### PR TITLE
Emulate error indicator, rather than metric

### DIFF
--- a/examples/models/stokes.py
+++ b/examples/models/stokes.py
@@ -4,7 +4,7 @@ from pyroteus_adjoint import *
 
 class Parameters(object):
     viscosity = Constant(1.0)
-    num_inputs = 23
+    num_inputs = 24
     num_outputs = 3
     dofs_per_element = 3
     h_min = 1.0e-05

--- a/examples/models/turbine.py
+++ b/examples/models/turbine.py
@@ -3,7 +3,7 @@ from pyroteus_adjoint import *
 
 
 class Parameters(object):
-    num_inputs = 23
+    num_inputs = 24
     num_outputs = 3
     dofs_per_element = 3
     h_min = 1.0e-05

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -73,6 +73,7 @@ print(f'    Element count        = {elements_old}')
 for fp_iteration in range(maxiter+1):
 
     # Compute goal-oriented metric
+    # TODO: isotropic mode
     p0metric, hessians, dwr, fwd_sol, adj_sol, dwr_plus, adj_sol_plus, mesh_seq = go_metric(mesh, config, **kwargs)
     dof = sum(fwd_sol.function_space().dof_count)
     print(f'    DoF count            = {dof}')
@@ -85,14 +86,10 @@ for fp_iteration in range(maxiter+1):
     P0 = dwr.function_space()
 
     # Extract features
-    features = extract_features(config, fwd_sol, hessians, preproc=preproc)
-    indices = [i*dim + j for i in range(dim) for j in range(i, dim)]
-    targets = np.reshape(p0metric.dat.data.flatten(), (elements_old, Nd))[:, indices]
-    indicator = dwr.dat.data.flatten()
+    features = extract_features(config, fwd_sol, adj_sol, mesh_seq, preproc=preproc)
+    targets = dwr.dat.data.flatten()
     assert not np.isnan(targets).any()
-    assert not np.isnan(indicator).any()
     np.save(f'{model}/data/features{test_case}_GO{fp_iteration}', features)
-    np.save(f'{model}/data/indicator{test_case}_GO{fp_iteration}', indicator)
     np.save(f'{model}/data/targets{test_case}_GO{fp_iteration}', targets)
 
     # Check for QoI convergence

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -73,6 +73,7 @@ for i in range(num_refinements+1):
     for fp_iteration in range(maxiter+1):
 
         # Compute goal-oriented metric
+        # TODO: isotropic mode
         p0metric, hessians, dwr, fwd_sol, adj_sol, dwr_plus, adj_sol_plus, mesh_seq = go_metric(mesh, config, **kwargs)
         dof = sum(fwd_sol.function_space().dof_count)
         print(f'      DoF count            = {dof}')

--- a/nn_adapt/ann.py
+++ b/nn_adapt/ann.py
@@ -41,24 +41,25 @@ class SimpleNet(nn.Module):
 
     Input layer:
     ============
-        [3 Stokes fields] x [3 unique Hessian entries]
-          x [2 forward/adjoint]
+        [9 forward DoFs per element]
+          + [9 adjoint DoFs per element]
           + [element orientation]
           + [element shape]
           + [element size]
           + [mesh Reynolds number]
           + [boundary element?]
-          = 23
+          + [error indicator on coarse mesh]
+          = 24
 
     Hidden layer:
     =============
-        720 neurons
+        240 neurons
 
     Output layer:
     =============
-        [3 unique metric entries]
+        [1 error indicator value]
     """
-    def __init__(self, num_inputs=23, num_outputs=3, num_hidden_neurons=720):
+    def __init__(self, num_inputs=24, num_outputs=1, num_hidden_neurons=240):
         super(SimpleNet, self).__init__()
         self.linear_1 = nn.Linear(num_inputs, num_hidden_neurons)
         self.activate_1 = nn.Tanh()

--- a/nn_adapt/features.py
+++ b/nn_adapt/features.py
@@ -2,6 +2,7 @@ import firedrake
 from firedrake.petsc import PETSc
 import numpy as np
 from pyroteus.metric import *
+from nn_adapt.solving import split_into_scalars
 import ufl
 
 
@@ -24,9 +25,10 @@ def extract_components(matrix):
     armin = ar.vector().gather().min()
     assert armin >= 1.0, f'An element has aspect ratio is less than one ({armin})'
     theta = firedrake.interpolate(ufl.atan(evecs[1, 1]/evecs[1, 0]), fs)
-    return density.dat.data, ar.dat.data, theta.dat.data
-    # h1 = firedrake.interpolate(ufl.cos(theta)**2/ar + ufl.sin(theta)**2*ar, fs)
-    # h2 = firedrake.interpolate((1/ar - ar)*ufl.sin(theta)*ufl.cos(theta), fs)
+    # return density.dat.data, ar.dat.data, theta.dat.data
+    h1 = firedrake.interpolate(ufl.cos(theta)**2/ar + ufl.sin(theta)**2*ar, fs)
+    h2 = firedrake.interpolate((1/ar - ar)*ufl.sin(theta)*ufl.cos(theta), fs)
+    return density.dat.data, h1.dat.data, h2.dat.data
     # H = firedrake.interpolate(ufl.as_matrix([[h1, h2], [h2, h1]]), matrix.function_space())
     # V, Lambda = compute_eigendecomposition(H)
     # lmin = Lambda.vector().gather().min()
@@ -37,36 +39,52 @@ def extract_components(matrix):
 
 
 @PETSc.Log.EventDecorator('nn_adapt.extract_features')
-def extract_features(config, fwd_sol, hessians, preproc='none'):
+def extract_features(config, fwd_sol, adj_sol, mesh_seq, preproc='none'):
     """
     Extract features from the outputs of a run.
 
     :arg config: the configuration file
     :arg fwd_sol: the forward solution
-    :arg hessians: Hessians of each component of
-        the forward and adjoint solutions
+    :arg adj_sol: the adjoint solution
     :kwarg preproc: preprocessor function
     """
     mesh = fwd_sol.function_space().mesh()
+    dim = mesh.topological_dimension()
     P0 = firedrake.FunctionSpace(mesh, 'DG', 0)
     P0_ten = firedrake.TensorFunctionSpace(mesh, 'DG', 0)
+
+    # Mesh Reynolds number
+    Re = config.parameters.Re(fwd_sol).dat.data
+
+    # Features describing the mesh element
     J = ufl.Jacobian(mesh)
     JTJ = firedrake.interpolate(ufl.dot(ufl.transpose(J), J), P0_ten)
-    Re = config.parameters.Re(fwd_sol).dat.data
+    d, h1, h2 = extract_components(JTJ)
     bnd_nodes = firedrake.DirichletBC(P0, 0, 'on_boundary').nodes
     bnd_tags = [
         1 if node in bnd_nodes else 0
         for node in range(mesh.num_cells())
     ]
-    hessians = [firedrake.interpolate(H, P0_ten) for H in hessians]
-    data = sum(
-        [list(extract_components(H)) for H in hessians],
-        start=[Re, bnd_tags, *extract_components(JTJ)]
-    )
+
+    # Features describing the forward and adjoint solutions
+    fwd_sols = split_into_scalars(fwd_sol)
+    adj_sols = split_into_scalars(adj_sol)
+    sols = sum([fi for i, fi in fwd_sols.items()], start=[]) \
+        + sum([ai for i, ai in adj_sols.items()], start=[])
+    vals = [get_values_at_elements(s).dat.data for s in sols]
+
+    # Coarse approximation of the error indicator
+    dwr = config.dwr_indicator(mesh_seq, fwd_sol, adj_sol)[0].dat.data
+
+    # Combine the features together
     num_inputs = config.parameters.num_inputs
     features = np.array([]).reshape(0, num_inputs)
     for i in range(mesh.num_cells()):
-        features = np.concatenate((features, np.reshape([d[i] for d in data], (1, num_inputs))))
+        mesh_features = [d[i], h1[i], h2[i], bnd_tags[i]]
+        solution_features = [v[i][j] for v in vals for j in range(3)]
+        feature = [Re[i]] + mesh_features + solution_features + [dwr[i]]
+        feature = np.reshape(feature, (1, num_inputs))
+        features = np.concatenate((features, feature))
     assert not np.isnan(features).any()
     return preprocess_features(features, preproc=preproc)
 

--- a/nn_adapt/metric.py
+++ b/nn_adapt/metric.py
@@ -50,14 +50,14 @@ def go_metric(mesh, config, enrichment_method='h', target_complexity=4000.0,
     dwr, fwd_sol, adj_sol, dwr_plus, adj_sol_plus, mesh_seq = indicate_errors(
         mesh, config, enrichment_method=enrichment_method, retall=True
     )
-    hessians = get_hessians(fwd_sol)
+    hessians = get_hessians(adj_sol)
     hessian = combine_metrics(*hessians, average=average)
     metric = anisotropic_metric(
         dwr, hessian, target_complexity=target_complexity,
         target_space=TensorFunctionSpace(mesh, 'DG', 0),
         interpolant=interpolant
     )
-    hessians = [*hessians, *get_hessians(adj_sol)]
+    hessians = [*get_hessians(adj_sol), *hessians]
     if retall:
         return metric, hessians, dwr, fwd_sol, adj_sol, dwr_plus, adj_sol_plus, mesh_seq
     else:


### PR DESCRIPTION
There are a number of reasons this is a good idea:
* orientation and shape information in the metric is inherited from the Hessian(s), which we already have
* having an error indicator means we can construct different metrics, rather than just one specific metric