### PR TITLE
Turn off learning rate adaptation by default

### DIFF
--- a/examples/compute_importance.py
+++ b/examples/compute_importance.py
@@ -14,7 +14,7 @@ import numpy as np
 
 # Parse model
 parser = argparse.ArgumentParser(
-    prog="plot_importance.py",
+    prog="compute_importance.py",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument(
@@ -52,12 +52,12 @@ parser.add_argument(
 parser.add_argument(
     "--tag",
     help="Model tag (defaults to current git commit sha)",
-    default=None,
+    default=git.Repo(search_parent_directories=True).head.object.hexsha,
 )
 parsed_args = parser.parse_args()
 model = parsed_args.model
 preproc = parsed_args.preproc
-tag = parsed_args.tag or git.Repo(search_parent_directories=True).head.object.hexsha
+tag = parsed_args.tag
 
 # Load the model
 layout = importlib.import_module(f"{model}.network").NetLayout()
@@ -83,10 +83,9 @@ for step in range(parsed_args.adaptation_steps):
                 key: np.load(f"{data_dir}/feature_{key}_{suffix}.npy")
                 for key in layout.inputs
             }
+            target = np.load(f"{data_dir}/target_{suffix}.npy")
             features = torch.from_numpy(collect_features(data)).type(torch.float32)
-            expected = torch.from_numpy(
-                np.load(f"{data_dir}/target_{suffix}.npy")
-            ).type(torch.float32)
+            expected = torch.from_numpy(target).type(torch.float32)
             features.requires_grad_(True)
 
             # Evaluate the loss

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -10,7 +10,6 @@ from nn_adapt.solving import *
 from nn_adapt.utility import ConvergenceTracker
 from firedrake.meshadapt import *
 
-import git
 import importlib
 from time import perf_counter
 
@@ -34,9 +33,9 @@ base_complexity = parsed_args.base_complexity
 target_complexity = parsed_args.target_complexity
 preproc = parsed_args.preproc
 optimise = parsed_args.optimise
+tag = parsed_args.tag
 if not optimise:
     from pyroteus.utility import File
-tag = parsed_args.tag or git.Repo(search_parent_directories=True).head.object.hexsha
 
 # Setup
 start_time = perf_counter()

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -11,7 +11,6 @@ from nn_adapt.solving import *
 from nn_adapt.utility import ConvergenceTracker
 from firedrake.meshadapt import *
 
-import git
 import importlib
 import numpy as np
 from time import perf_counter
@@ -43,7 +42,7 @@ except ValueError:
 approach = parsed_args.approach
 num_refinements = parsed_args.num_refinements
 preproc = parsed_args.preproc
-tag = parsed_args.tag or git.Repo(search_parent_directories=True).head.object.hexsha
+tag = parsed_args.tag
 base_complexity = parsed_args.base_complexity
 f = parsed_args.factor
 

--- a/nn_adapt/parse.py
+++ b/nn_adapt/parse.py
@@ -1,41 +1,40 @@
 import argparse
+import numpy as np
 
 
 __all__ = ["Parser"]
 
 
-def _check_positive(value, typ):
-    tvalue = typ(value)
-    if tvalue <= 0:
-        raise argparse.ArgumentTypeError(f"{value} is an invalid positive {typ} value")
-    return tvalue
-
-
-positive_float = lambda value: _check_positive(value, float)
-positive_int = lambda value: _check_positive(value, int)
-
-
-def _check_nonnegative(value, typ):
-    tvalue = typ(value)
-    if tvalue < 0:
-        raise argparse.ArgumentTypeError(f"{value} is an invalid positive {typ} value")
-    return tvalue
-
-
-nonnegative_float = lambda value: _check_nonnegative(value, float)
-nonnegative_int = lambda value: _check_nonnegative(value, int)
-
-
 def _check_in_range(value, typ, l, u):
     tvalue = typ(value)
     if not (tvalue >= l and tvalue <= u):
-        raise argparse.ArgumentTypeError(f"{value} is not bounded by {(l, u)}")
+        raise argparse.ArgumentTypeError(f"{value} is not in [{l}, {u}]")
     return tvalue
+
+
+def _check_strictly_in_range(value, typ, l, u):
+    tvalue = typ(value)
+    if not (tvalue >= l and tvalue <= u):
+        raise argparse.ArgumentTypeError(f"{value} is not in ({l}, {u})")
+    return tvalue
+
+
+nonnegative_float = lambda value: _check_in_range(value, float, 0, np.inf)
+nonnegative_int = lambda value: _check_in_range(value, int, 0, np.inf)
+positive_float = lambda value: _check_strictly_in_range(value, float, 0, np.inf)
+positive_int = lambda value: _check_strictly_in_range(value, int, 0, np.inf)
 
 
 def bounded_float(l, u):
     def chk(value):
         return _check_in_range(value, float, l, u)
+
+    return chk
+
+
+def bounded_int(l, u):
+    def chk(value):
+        return _check_in_range(value, int, l, u)
 
     return chk
 

--- a/nn_adapt/parse.py
+++ b/nn_adapt/parse.py
@@ -1,4 +1,5 @@
 import argparse
+import git
 import numpy as np
 
 
@@ -137,5 +138,5 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--tag",
             help="Model tag (defaults to current git commit sha)",
-            default=None,
+            default=git.Repo(search_parent_directories=True).head.object.hexsha,
         )


### PR DESCRIPTION
Inside `test_and_train.py`, there is functionality to adapt the learning rate, using the parameters `lr_adapt_num_steps` and `lr_adapt_factor`. Previously, the number of steps was set to 2000, meaning the learning rate would be decreased by `lr_adapt_factor` every 2000 iterations. This PR sets the default value to 0, i.e. turn it off unless the user specifies a positive value.

It also tidies up some of the other scripts that use ML and the way that bounded `int`s and `float`s are defined.