### PR TITLE
Fix sensitivity analysis experiment

### DIFF
--- a/examples/compute_importance.py
+++ b/examples/compute_importance.py
@@ -60,7 +60,7 @@ tag = parsed_args.tag
 
 # Load the model
 layout = importlib.import_module(f"{model}.network").NetLayout()
-nn = SingleLayerFCNN(layout).to(device)
+nn = SingleLayerFCNN(layout, preproc=preproc).to(device)
 nn.load_state_dict(torch.load(f"{model}/model_{tag}.pt"))
 nn.eval()
 loss_fn = Loss()

--- a/examples/compute_importance.py
+++ b/examples/compute_importance.py
@@ -66,10 +66,10 @@ nn.eval()
 loss_fn = Loss()
 
 # Compute (averaged) sensitivities of the network to the inputs
-sensitivity = torch.zeros(layout.num_inputs)
-count = 0
+dJdm = torch.zeros(layout.num_inputs)
 data_dir = f"{model}/data"
 approaches = parsed_args.approaches
+values = np.zeros((0, layout.num_inputs))
 for step in range(parsed_args.adaptation_steps):
     for approach in approaches:
         for test_case in range(1, parsed_args.num_training_cases + 1):
@@ -82,17 +82,21 @@ for step in range(parsed_args.adaptation_steps):
                 key: np.load(f"{data_dir}/feature_{key}_{suffix}.npy")
                 for key in layout.inputs
             }
-            target = np.load(f"{data_dir}/target_{suffix}.npy")
-            features = torch.from_numpy(collect_features(data)).type(torch.float32)
-            expected = torch.from_numpy(target).type(torch.float32)
+            features = collect_features(data)
+            values = np.vstack((values, features))
+            features = torch.from_numpy(features).type(torch.float32)
             features.requires_grad_(True)
 
-            # Evaluate the loss
-            loss = loss_fn(expected, nn(features))
+            # Run the model and sum the outputs
+            out = nn(features).sum(axis=0)
 
-            # Backpropagate and average to get the sensitivities
-            loss.backward()
-            sensitivity += features.grad.abs().mean(axis=0)
-            count += 1
-sensitivity /= count
+            # Backpropagate to get the gradient of the outputs w.r.t. the inputs
+            out.backward()
+            dJdm += features.grad.mean(axis=0)
+
+# Compute representative values for each parameter
+dm = np.abs(np.mean(values, axis=0))
+
+# Multiply by the variability
+sensitivity = dJdm.abs().detach().numpy() * dm
 np.save(f"{model}/data/sensitivities_{tag}.npy", sensitivity)

--- a/examples/plot_importance.py
+++ b/examples/plot_importance.py
@@ -41,20 +41,12 @@ parser.add_argument(
     default=3,
 )
 parser.add_argument(
-    "--preproc",
-    help="Data preprocess function",
-    type=str,
-    choices=["none", "arctan", "tanh", "logabs"],
-    default="arctan",
-)
-parser.add_argument(
     "--tag",
     help="Model tag (defaults to current git commit sha)",
     default=None,
 )
 parsed_args = parser.parse_args()
 model = parsed_args.model
-preproc = parsed_args.preproc
 tag = parsed_args.tag or git.Repo(search_parent_directories=True).head.object.hexsha
 
 # Separate sensitivity information by variable

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -46,7 +46,7 @@ mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 
 # Load the model
 layout = importlib.import_module(f"{model}.network").NetLayout()
-nn = SingleLayerFCNN(layout).to(device)
+nn = SingleLayerFCNN(layout, preproc=preproc).to(device)
 nn.load_state_dict(torch.load(f"{model}/model_{tag}.pt"))
 nn.eval()
 
@@ -103,9 +103,7 @@ for ct.fp_iteration in range(ct.maxiter + 1):
 
     # Extract features
     with PETSc.Log.Event("Network"):
-        features = collect_features(
-            extract_features(setup, fwd_sol, adj_sol, preproc=preproc)
-        )
+        features = collect_features(extract_features(setup, fwd_sol, adj_sol))
 
         # Run model
         with PETSc.Log.Event("Propagate"):

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -53,7 +53,7 @@ unit = setup.parameters.qoi_unit
 
 # Load the model
 layout = importlib.import_module(f"{model}.network").NetLayout()
-nn = SingleLayerFCNN(layout).to(device)
+nn = SingleLayerFCNN(layout, preproc=preproc).to(device)
 nn.load_state_dict(torch.load(f"{model}/model_{tag}.pt"))
 nn.eval()
 
@@ -108,9 +108,7 @@ for i in range(num_refinements + 1):
 
             # Extract features
             out["times"]["estimator"] = -perf_counter()
-            features = collect_features(
-                extract_features(setup, fwd_sol, adj_sol, preproc=preproc)
-            )
+            features = collect_features(extract_features(setup, fwd_sol, adj_sol))
 
             # Run model
             test_targets = np.array([])

--- a/examples/test_and_train.py
+++ b/examples/test_and_train.py
@@ -153,7 +153,7 @@ tag = parsed_args.tag
 layout = importlib.import_module(f"{model}.network").NetLayout()
 
 # Setup model
-nn = SingleLayerFCNN(layout).to(device)
+nn = SingleLayerFCNN(layout, preproc=preproc).to(device)
 optimizer = torch.optim.Adam(nn.parameters(), lr=lr)
 scheduler1 = lr_scheduler.ReduceLROnPlateau(
     optimizer,
@@ -180,7 +180,7 @@ if cuda:
     batch_size *= 4
     test_batch_size *= 4
 else:
-    dtype = torch.double
+    dtype = torch.float
 
 # Load data
 concat = lambda a, b: b if a is None else np.concatenate((a, b), axis=0)
@@ -197,7 +197,7 @@ for step in range(parsed_args.adaptation_steps):
                 key: np.load(f"{data_dir}/feature_{key}_{suffix}.npy")
                 for key in layout.inputs
             }
-            features = concat(features, collect_features(feature, preproc=preproc))
+            features = concat(features, collect_features(feature))
             target = np.load(f"{data_dir}/target_{suffix}.npy")
             targets = concat(targets, target)
 print(f"Total number of features: {len(features.flatten())}")


### PR DESCRIPTION
This PR changes the sensitivity analysis experiment so that (a) it differentiates the network output w.r.t. the controls, rather than the loss function and (b) this gradient then gets weighted by average values of the input parameters. This means that we get a better sense of "the sensitivity of the network w.r.t. its inputs", as opposed to just some gradient of the loss. However, it would be good to use representative values for each of the inputs, rather than just the means.

The PR also changes how the preprocessing function is applied. It is now a layer within the network definition, rather than being manually applied to the input data.