### PR TITLE
Refine the mesh adaptation approach

### DIFF
--- a/examples/plot_timings.py
+++ b/examples/plot_timings.py
@@ -28,6 +28,8 @@ def get_times(model, approach, case, it, tag=None):
     total = sum(split.values())
     for key, value in split.items():
         print(f"{approach} {key}: {value/total*100:.3f} %")
+    niter = np.load(f"{model}/data/niter_{approach}_{case}{ext}.npy")[it]
+    print(f"niter = {niter}")
     return split
 
 

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -50,6 +50,7 @@ mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 
 # Run adaptation loop
 kwargs = {
+    "interpolant": "Clement",
     "enrichment_method": "h",
     "average": False,
     "anisotropic": approach == "anisotropic",
@@ -87,12 +88,12 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     print(f"    Error estimator      = {estimator}")
     if "metric" not in out:
         break
-    adj_sol, dwr, p0metric = out["adjoint"], out["dwr"], out["metric"]
+    adj_sol, dwr, p1metric = out["adjoint"], out["dwr"], out["metric"]
     if not no_outputs:
         fwd_file.write(*fwd_sol.split())
         adj_file.write(*adj_sol.split())
         ee_file.write(dwr)
-        metric_file.write(p0metric)
+        metric_file.write(p1metric)
 
     def proj(V):
         """
@@ -122,8 +123,6 @@ for ct.fp_iteration in range(ct.maxiter + 1):
 
     # Process metric
     with PETSc.Log.Event("Metric construction"):
-        P1_ten = TensorFunctionSpace(mesh, "CG", 1)
-        p1metric = hessian_metric(clement_interpolant(p0metric))
         space_normalise(p1metric, target_ramp, "inf")
         enforce_element_constraints(
             p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -10,7 +10,7 @@ from nn_adapt.metric import *
 from nn_adapt.parse import Parser
 from nn_adapt.solving import *
 from nn_adapt.utility import ConvergenceTracker
-from firedrake.meshadapt import *
+from firedrake.meshadapt import adapt
 from firedrake.petsc import PETSc
 
 import importlib
@@ -55,6 +55,9 @@ kwargs = {
     "average": True,
     "anisotropic": approach == "anisotropic",
     "retall": True,
+    "h_min": setup.parameters.h_min,
+    "h_max": setup.parameters.h_max,
+    "a_max": 1.0e5,
 }
 ct = ConvergenceTracker(mesh, parsed_args)
 if not no_outputs:
@@ -73,8 +76,9 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     suffix = f"{test_case}_GO{approach}_{ct.fp_iteration}"
 
     # Ramp up the target complexity
-    target_ramp = ramp_complexity(base_complexity, target_complexity, ct.fp_iteration)
-    kwargs["target_complexity"] = target_ramp
+    kwargs["target_complexity"] = ramp_complexity(
+        base_complexity, target_complexity, ct.fp_iteration
+    )
 
     # Compute goal-oriented metric
     out = go_metric(mesh, setup, convergence_checker=ct, **kwargs)
@@ -88,12 +92,12 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     print(f"    Error estimator      = {estimator}")
     if "metric" not in out:
         break
-    adj_sol, dwr, p1metric = out["adjoint"], out["dwr"], out["metric"]
+    adj_sol, dwr, metric = out["adjoint"], out["dwr"], out["metric"]
     if not no_outputs:
         fwd_file.write(*fwd_sol.split())
         adj_file.write(*adj_sol.split())
         ee_file.write(dwr)
-        metric_file.write(p1metric)
+        metric_file.write(metric.function)
 
     def proj(V):
         """
@@ -120,15 +124,6 @@ for ct.fp_iteration in range(ct.maxiter + 1):
         for key, value in features.items():
             np.save(f"{data_dir}/feature_{key}_{suffix}", value)
         np.save(f"{data_dir}/target_{suffix}", target)
-
-    # Process metric
-    with PETSc.Log.Event("Metric construction"):
-        space_normalise(p1metric, target_ramp, "inf")
-        enforce_element_constraints(
-            p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05
-        )
-        metric = RiemannianMetric(mesh)
-        metric.assign(p1metric)
 
     # Adapt the mesh and check for element count convergence
     with PETSc.Log.Event("Mesh adaptation"):

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -52,7 +52,7 @@ mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 kwargs = {
     "interpolant": "Clement",
     "enrichment_method": "h",
-    "average": False,
+    "average": True,
     "anisotropic": approach == "anisotropic",
     "retall": True,
 }

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -133,25 +133,21 @@ for ct.fp_iteration in range(ct.maxiter + 1):
             hessian = combine_metrics(*get_hessians(fwd_sol), average=True)
         else:
             hessian = None
-        p1metric = anisotropic_metric(
+        M = anisotropic_metric(
             dwr,
             hessian=hessian,
             target_complexity=target_ramp,
             target_space=P1_ten,
             interpolant="Clement",
         )
-
-        # Process metric
-        space_normalise(p1metric, target_ramp, "inf")
+        space_normalise(M, target_ramp, "inf")
         enforce_element_constraints(
-            p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05
+            M, setup.parameters.h_min, setup.parameters.h_max, 1.0e05
         )
-
-        # Adapt the mesh and check for element count convergence
         metric = RiemannianMetric(mesh)
-        metric.assign(p1metric)
+        metric.assign(M)
     if not optimise:
-        metric_file.write(p1metric)
+        metric_file.write(M)
 
     # Adapt the mesh and check for element count convergence
     with PETSc.Log.Event("Mesh adaptation"):

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -130,7 +130,7 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     # Construct metric
     with PETSc.Log.Event("Metric construction"):
         if approach == "anisotropic":
-            hessian = combine_metrics(*get_hessians(fwd_sol), average=False)
+            hessian = combine_metrics(*get_hessians(fwd_sol), average=True)
         else:
             hessian = None
         p1metric = anisotropic_metric(

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -8,7 +8,7 @@ from nn_adapt.parse import Parser, positive_float
 from nn_adapt.metric import *
 from nn_adapt.solving import *
 from nn_adapt.utility import ConvergenceTracker
-from firedrake.meshadapt import *
+from firedrake.meshadapt import adapt
 
 import importlib
 import numpy as np
@@ -61,6 +61,9 @@ for i in range(num_refinements + 1):
             "average": True,
             "anisotropic": approach == "anisotropic",
             "retall": True,
+            "h_min": setup.parameters.h_min,
+            "h_max": setup.parameters.h_max,
+            "a_max": 1.0e5,
         }
         mesh = Mesh(f"{model}/meshes/{test_case}.msh")
         ct = ConvergenceTracker(mesh, parsed_args)
@@ -72,8 +75,9 @@ for i in range(num_refinements + 1):
         for ct.fp_iteration in range(ct.maxiter + 1):
 
             # Ramp up the target complexity
-            target_ramp = ramp_complexity(base_complexity, target_complexity, ct.fp_iteration)
-            kwargs["target_complexity"] = target_ramp
+            kwargs["target_complexity"] = ramp_complexity(
+                base_complexity, target_complexity, ct.fp_iteration
+            )
 
             # Compute goal-oriented metric
             out = go_metric(mesh, setup, convergence_checker=ct, **kwargs)
@@ -88,8 +92,12 @@ for i in range(num_refinements + 1):
             print(f"      Error estimator      = {estimator}")
             if "metric" not in out:
                 break
-            fwd_sol, adj_sol = out["forward"], out["adjoint"],
-            dwr, p1metric = out["dwr"], out["metric"]
+            times["metric"][-1] += out["times"]["metric"]
+            fwd_sol, adj_sol = (
+                out["forward"],
+                out["adjoint"],
+            )
+            dwr, metric = out["dwr"], out["metric"]
             dof = sum(fwd_sol.function_space().dof_count)
             print(f"      DoF count            = {dof}")
 
@@ -110,18 +118,7 @@ for i in range(num_refinements + 1):
             if parsed_args.transfer:
                 kwargs["init"] = proj
 
-            # Process metric
-            out["times"]["metric"] -= perf_counter()
-            space_normalise(p1metric, target_ramp, "inf")
-            enforce_element_constraints(
-                p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05
-            )
-
-            # Adapt the mesh and check for element count convergence
-            metric = RiemannianMetric(mesh)
-            metric.assign(p1metric)
-            out["times"]["metric"] += perf_counter()
-            times["metric"][-1] += out["times"]["metric"]
+            # Adapt the mesh
             out["times"]["adapt"] = -perf_counter()
             mesh = adapt(mesh, metric)
             out["times"]["adapt"] += perf_counter()

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -58,7 +58,7 @@ for i in range(num_refinements + 1):
         kwargs = {
             "enrichment_method": "h",
             "interpolant": "Clement",
-            "average": False,
+            "average": True,
             "anisotropic": approach == "anisotropic",
             "retall": True,
         }

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -57,6 +57,7 @@ for i in range(num_refinements + 1):
         target_complexity = 100.0 * 2 ** (f * i)
         kwargs = {
             "enrichment_method": "h",
+            "interpolant": "Clement",
             "average": False,
             "anisotropic": approach == "anisotropic",
             "retall": True,
@@ -88,7 +89,7 @@ for i in range(num_refinements + 1):
             if "metric" not in out:
                 break
             fwd_sol, adj_sol = out["forward"], out["adjoint"],
-            dwr, p0metric = out["dwr"], out["metric"]
+            dwr, p1metric = out["dwr"], out["metric"]
             dof = sum(fwd_sol.function_space().dof_count)
             print(f"      DoF count            = {dof}")
 
@@ -111,8 +112,6 @@ for i in range(num_refinements + 1):
 
             # Process metric
             out["times"]["metric"] -= perf_counter()
-            P1_ten = TensorFunctionSpace(mesh, "CG", 1)
-            p1metric = hessian_metric(clement_interpolant(p0metric))
             space_normalise(p1metric, target_ramp, "inf")
             enforce_element_constraints(
                 p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -134,7 +134,7 @@ for i in range(num_refinements + 1):
             # Construct metric
             out["times"]["metric"] = -perf_counter()
             if approach == "anisotropic":
-                hessian = combine_metrics(*get_hessians(fwd_sol), average=False)
+                hessian = combine_metrics(*get_hessians(fwd_sol), average=True)
             else:
                 hessian = None
             P1_ten = TensorFunctionSpace(mesh, "CG", 1)

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -137,18 +137,16 @@ for i in range(num_refinements + 1):
                 hessian = combine_metrics(*get_hessians(fwd_sol), average=False)
             else:
                 hessian = None
-            P0_ten = TensorFunctionSpace(mesh, "DG", 0)
-            p0metric = anisotropic_metric(
+            P1_ten = TensorFunctionSpace(mesh, "CG", 1)
+            p1metric = anisotropic_metric(
                 dwr,
-                hessian,
+                hessian=hessian,
                 target_complexity=target_ramp,
-                target_space=P0_ten,
-                interpolant="L2",
+                target_space=P1_ten,
+                interpolant="Clement",
             )
 
             # Process metric
-            P1_ten = TensorFunctionSpace(mesh, "CG", 1)
-            p1metric = hessian_metric(clement_interpolant(p0metric))
             space_normalise(p1metric, target_ramp, "inf")
             enforce_element_constraints(
                 p1metric, setup.parameters.h_min, setup.parameters.h_max, 1.0e05

--- a/nn_adapt/metric.py
+++ b/nn_adapt/metric.py
@@ -34,7 +34,7 @@ def go_metric(
     enrichment_method="h",
     target_complexity=4000.0,
     average=False,
-    interpolant="L2",
+    interpolant="Clement",
     anisotropic=False,
     retall=False,
     convergence_checker=None,
@@ -89,7 +89,7 @@ def go_metric(
             out["dwr"],
             hessian=hessian,
             target_complexity=target_complexity,
-            target_space=TensorFunctionSpace(mesh, "DG", 0),
+            target_space=TensorFunctionSpace(mesh, "CG", 1),
             interpolant=interpolant,
         )
     out["times"]["metric"] += perf_counter()

--- a/nn_adapt/metric.py
+++ b/nn_adapt/metric.py
@@ -5,6 +5,7 @@ fields.
 from pyroteus import *
 from nn_adapt.features import split_into_scalars
 from nn_adapt.solving import *
+from firedrake.meshadapt import RiemannianMetric
 from time import perf_counter
 
 
@@ -58,12 +59,18 @@ def go_metric(
         interpolate into the target space?
     :kwarg anisotropic: toggle isotropic vs.
         anisotropic metric
+    :kwarg h_min: minimum magnitude
+    :kwarg h_max: maximum magnitude
+    :kwarg a_max: maximum anisotropy
     :kwarg retall: if ``True``, the error indicator,
         forward solution and adjoint solution
         are returned, in addition to the metric
     :kwarg convergence_checker: :class:`ConvergenceTracer`
         instance
     """
+    h_min = kwargs.pop("h_min", 1.0e-30)
+    h_max = kwargs.pop("h_max", 1.0e+30)
+    a_max = kwargs.pop("a_max", 1.0e+30)
     out = indicate_errors(
         mesh,
         config,
@@ -85,12 +92,16 @@ def go_metric(
             hessian = combine_metrics(*get_hessians(out["forward"]), average=average)
         else:
             hessian = None
-        out["metric"] = anisotropic_metric(
+        metric = anisotropic_metric(
             out["dwr"],
             hessian=hessian,
             target_complexity=target_complexity,
             target_space=TensorFunctionSpace(mesh, "CG", 1),
             interpolant=interpolant,
         )
+        space_normalise(metric, target_complexity, "inf")
+        enforce_element_constraints(metric, h_min, h_max, a_max)
+        out["metric"] = RiemannianMetric(mesh)
+        out["metric"].assign(metric)
     out["times"]["metric"] += perf_counter()
     return out if retall else out["metric"]

--- a/nn_adapt/metric.py
+++ b/nn_adapt/metric.py
@@ -33,7 +33,7 @@ def go_metric(
     config,
     enrichment_method="h",
     target_complexity=4000.0,
-    average=False,
+    average=True,
     interpolant="Clement",
     anisotropic=False,
     retall=False,


### PR DESCRIPTION
This PR contains some refinements for the metric-based mesh adaptation strategy:
* Avoid transferring into P0 space unnecessarily.
* Use metric averaging rather than metric intersection - it is better for convergence analysis.
* Put much of the metric processing details in `nn_adapt/metric.py`, rather than the example scripts.
* Use Clement interpolation for metrics.