### PR TITLE
Add a simple Burgers example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,6 @@ finite element method is used -- P1DG for velocity and P2 for free surface eleva
 Adding a new model `foo` would require a few things:
 
 * A `models/foo.py` model description file, which should mimic `models/turbine.py` and include all the same functions for setting up and solving the problem.
-* A `foo/__init__.py` initialisation file, which is probably empty.
 * A problem configuration file `foo/config.py`, which reads from `models/foo.py` and initialises parameter classes as required.
 * A `foo/meshgen.py` file for generating gmsh geometry files associated with the initial meshes, driven by a function ``generate_geo``.
 * A `foo/network.py` file for setting up the neural network architecture.

--- a/examples/burgers/config.py
+++ b/examples/burgers/config.py
@@ -1,0 +1,48 @@
+from models.burgers import *
+import numpy as np
+
+
+testing_cases = ["demo"]
+
+
+def sample_uniform(l, u):
+    """
+    Sample from the continuous uniform
+    distribution :math:`U(l, u)`.
+
+    :arg l: the lower bound
+    :arg u: the upper bound
+    """
+    return l + (u - l) * np.random.rand()
+
+
+def initialise(case, discrete=False):
+    """
+    Given some training case (for which ``case``
+    is an integer) or testing case (for which
+    ``case`` is a string), set up the physical
+    problems defining the Burgers problem.
+
+    For training data, these values are chosen
+    randomly.
+    """
+    parameters.case = case
+    parameters.discrete = discrete
+    if isinstance(case, int):
+        parameters.turbine_coords = []
+        np.random.seed(100 * case)
+
+        # Random initial speed from 0.01 m/s to 6 m/s
+        parameters.initial_speed = sample_uniform(0.01, 6.0)
+
+        # Random viscosity from 0.00001 m^2/s to 1 m^2/s
+        parameters.viscosity_coefficient = sample_uniform(0.1, 1.0) * 10 ** np.random.randint(-3, 1)
+        return
+    elif "demo" in case:
+        parameters.viscosity_coefficient = 0.0001
+        parameters.initial_speed = 1.0
+    else:
+        raise ValueError(f"Test case {test_case} not recognised")
+
+    if "reversed" in case:
+        parameters.initial_speed *= -1

--- a/examples/burgers/config.py
+++ b/examples/burgers/config.py
@@ -1,19 +1,9 @@
 from models.burgers import *
+from nn_adapt.ann import sample_uniform
 import numpy as np
 
 
 testing_cases = ["demo"]
-
-
-def sample_uniform(l, u):
-    """
-    Sample from the continuous uniform
-    distribution :math:`U(l, u)`.
-
-    :arg l: the lower bound
-    :arg u: the upper bound
-    """
-    return l + (u - l) * np.random.rand()
 
 
 def initialise(case, discrete=False):

--- a/examples/burgers/meshgen.py
+++ b/examples/burgers/meshgen.py
@@ -1,0 +1,2 @@
+def generate_geo(config, reverse=False):
+    return

--- a/examples/burgers/network.py
+++ b/examples/burgers/network.py
@@ -14,14 +14,14 @@ class NetLayout(NetLayoutBase):
           + [element orientation]
           + [element shape]
           + [boundary element?]
-          + [2 forward DoFs per element]
-          + [2 adjoint DoFs per element]
-          = 10
+          + [12 forward DoFs per element]
+          + [12 adjoint DoFs per element]
+          = 30
 
     Hidden layer:
     -------------
 
-        20 neurons
+        60 neurons
 
     Output layer:
     -------------
@@ -39,4 +39,5 @@ class NetLayout(NetLayoutBase):
         "forward_dofs",
         "adjoint_dofs",
     )
-    num_hidden_neurons = 20
+    num_hidden_neurons = 60
+    dofs_per_element = 12

--- a/examples/burgers/network.py
+++ b/examples/burgers/network.py
@@ -1,0 +1,42 @@
+from nn_adapt.layout import NetLayoutBase
+
+
+class NetLayout(NetLayoutBase):
+    """
+    Default configuration
+    =====================
+
+    Input layer:
+    ------------
+        [coarse-grained DWR]
+          + [viscosity coefficient]
+          + [element size]
+          + [element orientation]
+          + [element shape]
+          + [boundary element?]
+          + [2 forward DoFs per element]
+          + [2 adjoint DoFs per element]
+          = 10
+
+    Hidden layer:
+    -------------
+
+        20 neurons
+
+    Output layer:
+    -------------
+
+        [1 error indicator value]
+    """
+
+    inputs = (
+        "estimator_coarse",
+        "physics_viscosity",
+        "mesh_d",
+        "mesh_h1",
+        "mesh_h2",
+        "mesh_bnd",
+        "forward_dofs",
+        "adjoint_dofs",
+    )
+    num_hidden_neurons = 20

--- a/examples/compute_importance.py
+++ b/examples/compute_importance.py
@@ -82,7 +82,7 @@ for step in range(parsed_args.adaptation_steps):
                 key: np.load(f"{data_dir}/feature_{key}_{suffix}.npy")
                 for key in layout.inputs
             }
-            features = collect_features(data)
+            features = collect_features(data, layout)
             values = np.vstack((values, features))
             features = torch.from_numpy(features).type(torch.float32)
             features.requires_grad_(True)

--- a/examples/makefile
+++ b/examples/makefile
@@ -55,7 +55,9 @@ mesh:
 	d=$$(date +%s) && \
 	for case in $(CASES); do \
 		python3 meshgen.py $(MODEL) $$case; \
-		gmsh -2 -algo pack $(MODEL)/meshes/$$case.geo -o $(MODEL)/meshes/$$case.msh; \
+		if [ -e $(MODEL)/meshes/$$case.geo ]; then \
+			gmsh -2 -algo pack $(MODEL)/meshes/$$case.geo -o $(MODEL)/meshes/$$case.msh; \
+	    fi; \
 	done && \
 	date >> timing.log && \
 	git log -n 1 --oneline >> timing.log && \

--- a/examples/models/burgers.py
+++ b/examples/models/burgers.py
@@ -1,0 +1,165 @@
+from firedrake import *
+from firedrake.petsc import PETSc
+import nn_adapt.model
+import nn_adapt.solving
+
+
+class Parameters(nn_adapt.model.Parameters):
+    """
+    Class encapsulating all parameters required for a simple
+    Burgers equation test case.
+    """
+
+    qoi_name = "right boundary integral"
+    qoi_unit = r"m\,s^{-1}"
+
+    # Adaptation parameters
+    h_min = 1.0e-10  # Minimum metric magnitude
+    h_max = 1.0  # Maximum metric magnitude
+
+    # Physical parameters
+    viscosity_coefficient = 0.0001
+    initial_speed = 1.0
+
+    # Timestepping parameters
+    timestep = 0.05
+
+    solver_parameters = {}
+    adjoint_solver_parameters = {}
+
+    def bathymetry(self, mesh):
+        """
+        Compute the bathymetry field on the current `mesh`.
+
+        Note that there isn't really a concept of bathymetry
+        for Burgers equation. It is kept constant and should
+        be ignored by the network.
+        """
+        P0_2d = FunctionSpace(mesh, "DG", 0)
+        return Function(P0_2d).assign(1.0)
+
+    def drag(self, mesh):
+        """
+        Compute the bathymetry field on the current `mesh`.
+
+        Note that there isn't really a concept of bathymetry
+        for Burgers equation. It is kept constant and should
+        be ignored by the network.
+        """
+        P0_2d = FunctionSpace(mesh, "DG", 0)
+        return Function(P0_2d).assign(1.0)
+
+    def viscosity(self, mesh):
+        """
+        Compute the viscosity coefficient on the current `mesh`.
+        """
+        P0_2d = FunctionSpace(mesh, "DG", 0)
+        return Function(P0_2d).assign(self.viscosity_coefficient)
+
+    def ic(self, mesh):
+        """
+        Initial condition
+        """
+        x, y = SpatialCoordinate(mesh)
+        expr = self.initial_speed * sin(pi * x)
+        return as_vector([expr, 0])
+
+
+PETSc.Sys.popErrorHandler()
+parameters = Parameters()
+
+
+def get_function_space(mesh):
+    r"""
+    Construct the :math:`\mathbb P2` finite element space
+    used for the prognostic solution.
+    """
+    return VectorFunctionSpace(mesh, "CG", 2)
+
+
+class Solver(nn_adapt.solving.Solver):
+    """
+    Solver object based on current mesh and state.
+    """
+
+    def __init__(self, mesh, ic, **kwargs):
+        """
+        :arg mesh: the mesh to define the solver on
+        :arg ic: the current state / initial condition
+        """
+        self.mesh = mesh
+
+        # Collect parameters
+        dt = Constant(parameters.timestep)
+        nu = parameters.viscosity(mesh)
+
+        # Define variational formulation
+        V = self.function_space
+        u = Function(V)
+        u_ = Function(V)
+        v = TestFunction(V)
+        self._form = (
+            inner((u - u_) / dt, v) * dx
+            + inner(dot(u, nabla_grad(u)), v) * dx
+            + nu * inner(grad(u), grad(v)) * dx
+        )
+        problem = NonlinearVariationalProblem(self._form, u)
+
+        # Set initial condition
+        u_.project(parameters.ic(mesh))
+
+        # Create solver
+        self._solver = NonlinearVariationalSolver(problem)
+        self._solution = u
+
+    @property
+    def function_space(self):
+        r"""
+        The :math:`\mathbb P2` finite element space.
+        """
+        return get_function_space(self.mesh)
+
+    @property
+    def form(self):
+        """
+        The weak form of Burgers equation
+        """
+        return self._form
+
+    @property
+    def solution(self):
+        return self._solution
+
+    def iterate(self, **kwargs):
+        """
+        Take a single timestep of Burgers equation
+        """
+        self._solver.solve()
+
+
+def get_initial_condition(function_space):
+    """
+    Compute an initial condition based on the initial
+    speed parameter.
+    """
+    u = Function(function_space)
+    u.interpolate(parameters.ic(function_space.mesh()))
+    return u
+
+
+def get_qoi(mesh):
+    """
+    Extract the quantity of interest function from the :class:`Parameters`
+    object.
+
+    It should have one argument - the prognostic solution.
+    """
+
+    def qoi(sol):
+        return inner(sol, sol) * ds(2)
+
+    return qoi
+
+
+# Initial mesh for all test cases
+initial_mesh = UnitSquareMesh(30, 30)

--- a/examples/plot_progress.py
+++ b/examples/plot_progress.py
@@ -18,7 +18,7 @@ parser.add_argument(
     "model",
     help="The model",
     type=str,
-    choices=["steady_turbine"],
+    choices=["steady_turbine", "burgers"],
 )
 parser.add_argument(
     "--tag",

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -87,7 +87,7 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     out = go_metric(mesh, setup, convergence_checker=ct, **kwargs)
     qoi, fwd_sol = out["qoi"], out["forward"]
     print(f"    Quantity of Interest = {qoi} {unit}")
-    dof = sum(fwd_sol.function_space().dof_count)
+    dof = sum(np.array([fwd_sol.function_space().dof_count]).flatten())
     print(f"    DoF count            = {dof}")
     if "adjoint" not in out:
         break

--- a/examples/run_adapt.py
+++ b/examples/run_adapt.py
@@ -46,7 +46,10 @@ start_time = perf_counter()
 setup = importlib.import_module(f"{model}.config")
 setup.initialise(test_case)
 unit = setup.parameters.qoi_unit
-mesh = Mesh(f"{model}/meshes/{test_case}.msh")
+if hasattr(setup, "initial_mesh"):
+    mesh = setup.initial_mesh
+else:
+    mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 
 # Run adaptation loop
 kwargs = {

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -106,7 +106,7 @@ for ct.fp_iteration in range(ct.maxiter + 1):
 
     # Extract features
     with PETSc.Log.Event("Network"):
-        features = collect_features(extract_features(setup, fwd_sol, adj_sol))
+        features = collect_features(extract_features(setup, fwd_sol, adj_sol), layout)
 
         # Run model
         with PETSc.Log.Event("Propagate"):

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -42,7 +42,10 @@ start_time = perf_counter()
 setup = importlib.import_module(f"{model}.config")
 setup.initialise(test_case)
 unit = setup.parameters.qoi_unit
-mesh = Mesh(f"{model}/meshes/{test_case}.msh")
+if hasattr(setup, "initial_mesh"):
+    mesh = setup.initial_mesh
+else:
+    mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 
 # Load the model
 layout = importlib.import_module(f"{model}.network").NetLayout()

--- a/examples/run_adapt_ml.py
+++ b/examples/run_adapt_ml.py
@@ -76,7 +76,7 @@ for ct.fp_iteration in range(ct.maxiter + 1):
     out = get_solutions(mesh, setup, convergence_checker=ct, **kwargs)
     qoi, fwd_sol = out["qoi"], out["forward"]
     print(f"    Quantity of Interest = {qoi} {unit}")
-    dof = sum(fwd_sol.function_space().dof_count)
+    dof = sum(np.array([fwd_sol.function_space().dof_count]).flatten())
     print(f"    DoF count            = {dof}")
     if "adjoint" not in out:
         break

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -101,7 +101,7 @@ for i in range(num_refinements + 1):
                 out["adjoint"],
             )
             dwr, metric = out["dwr"], out["metric"]
-            dof = sum(fwd_sol.function_space().dof_count)
+            dof = sum(np.array([fwd_sol.function_space().dof_count]).flatten())
             print(f"      DoF count            = {dof}")
 
             def proj(V):

--- a/examples/run_adaptation_loop.py
+++ b/examples/run_adaptation_loop.py
@@ -65,7 +65,10 @@ for i in range(num_refinements + 1):
             "h_max": setup.parameters.h_max,
             "a_max": 1.0e5,
         }
-        mesh = Mesh(f"{model}/meshes/{test_case}.msh")
+        if hasattr(setup, "initial_mesh"):
+            mesh = setup.initial_mesh
+        else:
+            mesh = Mesh(f"{model}/meshes/{test_case}.msh")
         ct = ConvergenceTracker(mesh, parsed_args)
         print(f"  Target {target_complexity}\n    Mesh 0")
         print(f"      Element count        = {ct.elements_old}")

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -66,7 +66,10 @@ print(f"Test case {test_case}")
 for i in range(num_refinements + 1):
     try:
         target_complexity = 100.0 * 2 ** (f * i)
-        mesh = Mesh(f"{model}/meshes/{test_case}.msh")
+        if hasattr(setup, "initial_mesh"):
+            mesh = setup.initial_mesh
+        else:
+            mesh = Mesh(f"{model}/meshes/{test_case}.msh")
         ct = ConvergenceTracker(mesh, parsed_args)
         kwargs = {}
         print(f"  Target {target_complexity}\n    Mesh 0")

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -93,6 +93,8 @@ for i in range(num_refinements + 1):
                 break
             times["adjoint"][-1] += out["times"]["adjoint"]
             fwd_sol, adj_sol = out["forward"], out["adjoint"]
+            dof = sum(np.array([fwd_sol.function_space().dof_count]).flatten())
+            print(f"      DoF count            = {dof}")
 
             def proj(V):
                 """
@@ -175,7 +177,7 @@ for i in range(num_refinements + 1):
         )
         times["all"][-1] += perf_counter()
         qois.append(qoi)
-        dofs.append(sum(fwd_sol.function_space().dof_count))
+        dofs.append(dof)
         elements.append(cells)
         estimators.append(estimator)
         niter.append(ct.fp_iteration + 1)

--- a/examples/run_adaptation_loop_ml.py
+++ b/examples/run_adaptation_loop_ml.py
@@ -115,7 +115,8 @@ for i in range(num_refinements + 1):
 
             # Extract features
             out["times"]["estimator"] = -perf_counter()
-            features = collect_features(extract_features(setup, fwd_sol, adj_sol))
+            features = extract_features(setup, fwd_sol, adj_sol)
+            features = collect_features(features, layout)
 
             # Run model
             test_targets = np.array([])

--- a/examples/run_fixed_mesh.py
+++ b/examples/run_fixed_mesh.py
@@ -26,7 +26,10 @@ except ValueError:
 setup = importlib.import_module(f"{model}.config")
 setup.initialise(test_case)
 unit = setup.parameters.qoi_unit
-mesh = Mesh(f"{model}/meshes/{test_case}.msh")
+if hasattr(setup, "initial_mesh"):
+    mesh = setup.initial_mesh
+else:
+    mesh = Mesh(f"{model}/meshes/{test_case}.msh")
 if parsed_args.num_refinements > 0:
     with PETSc.Log.Event("Hierarchy"):
         mesh = MeshHierarchy(mesh, parsed_args.num_refinements)[-1]

--- a/examples/steady_turbine/config.py
+++ b/examples/steady_turbine/config.py
@@ -1,4 +1,5 @@
 from models.steady_turbine import *
+from nn_adapt.ann import sample_uniform
 
 
 testing_cases = ["aligned", "offset"]
@@ -11,17 +12,6 @@ def l2dist(xy, xyt):
     """
     diff = np.array(xy) - np.array(xyt)
     return np.sqrt(np.dot(diff, diff))
-
-
-def sample_uniform(l, u):
-    """
-    Sample from the continuous uniform
-    distribution :math:`U(l, u)`.
-
-    :arg l: the lower bound
-    :arg u: the upper bound
-    """
-    return l + (u - l) * np.random.rand()
 
 
 def initialise(case, discrete=False):

--- a/examples/steady_turbine/network.py
+++ b/examples/steady_turbine/network.py
@@ -44,3 +44,4 @@ class NetLayout(NetLayoutBase):
         "adjoint_dofs",
     )
     num_hidden_neurons = 64
+    dofs_per_element = 12

--- a/nn_adapt/ann.py
+++ b/nn_adapt/ann.py
@@ -31,6 +31,17 @@ def set_seed(seed):
     torch.cuda.manual_seed_all(seed)
 
 
+def sample_uniform(l, u):
+    """
+    Sample from the continuous uniform
+    distribution :math:`U(l, u)`.
+
+    :arg l: the lower bound
+    :arg u: the upper bound
+    """
+    return l + (u - l) * np.random.rand()
+
+
 class SingleLayerFCNN(nn.Module):
     """
     Fully Connected Neural Network (FCNN)

--- a/nn_adapt/ann.py
+++ b/nn_adapt/ann.py
@@ -119,15 +119,17 @@ def propagate(data_loader, model, loss_fn, optimizer=None):
     return cumulative_loss / num_batches
 
 
-def collect_features(feature_dict):
+def collect_features(feature_dict, layout):
     """
     Given a dictionary of feature arrays, stack their
     data appropriately to be fed into a neural network.
 
     :arg feature_dict: dictionary containing feature data
+    :arg layout: :class:`NetLayout` instance
     """
-    dofs = [feature for key, feature in feature_dict.items() if "dofs" in key]
-    nodofs = [feature for key, feature in feature_dict.items() if "dofs" not in key]
+    features = {key: val for key, val in feature_dict.items() if key in layout.inputs}
+    dofs = [feature for key, feature in features.items() if "dofs" in key]
+    nodofs = [feature for key, feature in features.items() if "dofs" not in key]
     return np.hstack((np.vstack(nodofs).transpose(), np.hstack(dofs)))
 
 

--- a/nn_adapt/layout.py
+++ b/nn_adapt/layout.py
@@ -13,8 +13,6 @@ class NetLayoutBase(object):
     for each of these parameters.
     """
 
-    inputs = None
-    num_hidden_neurons = None
     # TODO: Allow more general networks
 
     colours = {
@@ -26,8 +24,8 @@ class NetLayoutBase(object):
     }
 
     def __init__(self):
-        if self.inputs is None:
-            raise ValueError("Need to set inputs")
+        if not hasattr(self, "inputs"):
+            raise ValueError("Need to set self.inputs")
         colours = set(self.colours.keys())
         for i in self.inputs:
             okay = False
@@ -37,8 +35,10 @@ class NetLayoutBase(object):
                     break
             if not okay:
                 raise ValueError("Input names must begin with one of {colours}")
-        if self.num_hidden_neurons is None:
-            raise ValueError("Need to set number of hidden neurons")
+        if not hasattr(self, "num_hidden_neurons"):
+            raise ValueError("Need to set self.num_hidden_neurons")
+        if not hasattr(self, "dofs_per_element"):
+            raise ValueError("Need to set self.dofs_per_element")
 
     def count_inputs(self, prefix):
         """
@@ -48,7 +48,7 @@ class NetLayoutBase(object):
         for i in self.inputs:
             if i.startswith(prefix):
                 if i in ("forward_dofs", "adjoint_dofs"):
-                    cnt += 12
+                    cnt += self.dofs_per_element
                 else:
                     cnt += 1
         return cnt


### PR DESCRIPTION
Setup based on [this notebook](https://nbviewer.org/github/firedrakeproject/firedrake/blob/master/docs/notebooks/11-extract-adjoint-solutions.ipynb). At present, we only consider one timestep and the initial condition is always a scaling of the same sinusoid. The QoI is always the same integral over the right hand boundary.

For simplicity, the same uniform mesh is used initially in each case. There were some minor changes required to the code to support the case with a non-mixed vector function space. Coincidentally, the number of DoFs per element is 12, as with the existing steady-state shallow water example.

To test out this new example, change the `MODEL` variable to `burgers` in the makefile.